### PR TITLE
Possible missing break in bin\keychain.php at line 77?

### DIFF
--- a/bin/keychain
+++ b/bin/keychain
@@ -94,6 +94,7 @@ class KeychainManager extends \Joomla\Application\AbstractCliApplication
 				break;
 			case 'change':
 				$this->change();
+				break;
 			case 'delete':
 				$this->delete();
 				break;


### PR DESCRIPTION
>Is there a reason for the missing break statement at line 77 in bin\keychain.php at the case 'change':? 
Seems like this would be (or could cause) an error by omission.

See: https://github.com/joomla/joomla-cms/issues/6672 by @photodude