### PR TITLE
[codestyle] Fixed first letter casing in method names

### DIFF
--- a/Tests/KeychainTest.php
+++ b/Tests/KeychainTest.php
@@ -54,7 +54,7 @@ class KeychainTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testLoadCLIKeychain()
+	public function testLoadCliKeychain()
 	{
 		$keychain = new Keychain;
 


### PR DESCRIPTION
This PR fixes some more method names to comply with the CamelCase rules mentioned here:
http://joomla.github.io/coding-standards/?coding-standards/chapters/php.md
> ...be written in CamelCase even if using traditionally uppercase acronyms (such as XML, HTML).

Not touching casing of class names as this requires changes in casing in file names and causes issues at this point.