### PR TITLE
Method call with an extra parameter

### DIFF
--- a/bin/keychain
+++ b/bin/keychain
@@ -298,7 +298,7 @@ class KeychainManager extends \Joomla\Application\AbstractCliApplication
 		}
 
 		$this->updated = true;
-		$this->keychain->deleteValue($this->input->args[1], null);
+		$this->keychain->deleteValue($this->input->args[1]);
 	}
 
 	/**


### PR DESCRIPTION
Method call uses 2 parameters, but method signature uses 1 parameter 

Fixes: https://github.com/joomla/joomla-cms/pull/8818

